### PR TITLE
[Fix] remove cuda11.8 version support in env template.

### DIFF
--- a/conda/create_conda_env.sh
+++ b/conda/create_conda_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly CUDA_VERSIONS="11.7,11.8"
+readonly CUDA_VERSIONS="11.7"
 readonly TORCH_VERSION="1.13.1"
 readonly PYTHON_VERSION="3.9"
 readonly DGL_VERSION="2.1a240205"

--- a/conda/env.yml.template
+++ b/conda/env.yml.template
@@ -34,7 +34,6 @@ dependencies:
     - featuretools
     - transformers
     - boto3
-    - mysqlclient
     - sqlalchemy
     - sqlalchemy_schemadisplay
     - openai


### PR DESCRIPTION

### Description

when I follow the README to create conda environment under the cuda verison 11.8, execute
```shell
bash conda/create_conda_env.sh -g 11.8 -p 3.9
```

it will raise `ERROR: Could not find a version that satisfies the requirement torch==1.13.1+cu118`


I have checked the official document of Pytorch [link](https://pytorch.org/get-started/previous-versions/#v1131). `torch 1.13.1` only support cuda version `11.7` and `11.6`.

However, I think `cuda 11.8` should be compatible for previous version. using `11.7` should be ok there.

### Modification
I removed the `11.8` in supported cuda version in help message of `create_conda_env.sh`.

### Addition
I try to create the conda environment in server without sudo permission.

So I didn't execute  `bash conda/install-ubuntu-deps.sh` to download the `libmysqlclient-dev` dependency, leading to the fail in downloading `mysqlclient`  package.

I removed the `mysqlclient` dependency in `env.yml.template` file and can successfully create environment.

I'm wondering the role of `mysqlclient` in the entire package. QAQ
Will it affect usage of this benchmark without `mysqlclient`?